### PR TITLE
Fix broken strings on Python 2.7

### DIFF
--- a/scraperwiki/sql.py
+++ b/scraperwiki/sql.py
@@ -35,8 +35,11 @@ PYTHON_SQLITE_TYPE_MAP = {
     datetime.datetime: sqlalchemy.types.DateTime,
 
     Blob: sqlalchemy.types.LargeBinary,
-    bytes: sqlalchemy.types.LargeBinary,
 }
+
+if bytes is not str:
+    # On 2.7, bytes *is* str, so we don't want to overwrite that.
+    PYTHON_SQLITE_TYPE_MAP[bytes] = sqlalchemy.types.LargeBinary
 
 try:
     PYTHON_SQLITE_TYPE_MAP[long] = sqlalchemy.types.BigInteger

--- a/tests.py
+++ b/tests.py
@@ -195,7 +195,7 @@ class TestSaveColumn(TestCase):
 
         script = dedent(u"""
           import scraperwiki
-          scraperwiki.sql.save(['id'], dict(id=1, a="bar\xaa", b="foo\xaa"))
+          scraperwiki.sql.save(['id'], dict(id=1, a=u"bar\xaa", b=u"foo\xaa"))
           """)
         with open("/dev/null") as null:
             process = Popen([sys.executable, "-c", script],

--- a/tests.py
+++ b/tests.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 import datetime
+import json
 import os
 import re
 import shutil
@@ -217,6 +218,12 @@ class TestSave(SaveAndCheck):
             {u"lastname\xaa": u"LeTourneau\u1234"}, u"diesel-engineers\xaa", [
                 (u'LeTourneau\u1234',)]
         )
+
+        # Ensure we can round-trip a string and then json encode it.
+        # https://github.com/scraperwiki/scraperwiki-python/pull/85
+        scraperwiki.sql.save([], {"test": "teststring"}, table_name="teststring")
+        data = scraperwiki.sql.select("* FROM teststring")
+        json.dumps(data)
 
     def test_save_twice(self):
         self.save_and_check(


### PR DESCRIPTION
In 2.7, bytes is equal to str, so if you saved a string to a database
you would end up with a BLOB column. This breaks dumptruck and the
view-in-the-table tool, among other things.