### PR TITLE
Don't insert unicode names twice: #86

### DIFF
--- a/scraperwiki/sql.py
+++ b/scraperwiki/sql.py
@@ -342,7 +342,7 @@ def fit_row(connection, row, unique_keys):
         new_column = sqlalchemy.Column(column_name,
                                        get_column_type(column_value))
 
-        if not str(new_column) in list(_State.table.columns.keys()):
+        if not column_name in list(_State.table.columns.keys()):
             new_columns.append(new_column)
             _State.table.append_column(new_column)
 

--- a/tests.py
+++ b/tests.py
@@ -357,6 +357,11 @@ class TestStatus(TestCase):
 
     # XXX neeed some mocking tests for case of run inside a box
 
+class TestUnicodeColumns(TestCase):
+    maxDiff = None
+    def test_add_column_once_only(self):
+        scraperwiki.sqlite.save(data = {"i": 1, u"a\xa0b": 1}, unique_keys = ['i'])
+        scraperwiki.sqlite.save(data = {"i": 2, u"a\xa0b": 2}, unique_keys = ['i'])
 
 class TestImports(TestCase):
 


### PR DESCRIPTION
Resolves #86 -- str(new_column) of a column containing `u'a\xa0b'` is `u'a\\xa0b'` -- we already have a nice name in `column_name`. 

With tests, py23 compatible (bug was py2 only)