### PR TITLE
Naive implementation of scraperwiki.swimport().

### DIFF
--- a/scraperwiki/__init__.py
+++ b/scraperwiki/__init__.py
@@ -7,7 +7,7 @@ https://scraperwiki.com/docs/python/python_help_documentation/
 '''
 from __future__ import absolute_import
 
-from .utils import scrape, pdftoxml, status
+from .utils import scrape, pdftoxml, status, swimport
 from . import utils
 from . import sql
 

--- a/scraperwiki/utils.py
+++ b/scraperwiki/utils.py
@@ -80,3 +80,6 @@ def status(type, message=None):
     r = requests.post(url, data={'type': type, 'message': message})
     r.raise_for_status()
     return r.content
+
+def swimport(scrapername):
+    return __import__(scrapername)


### PR DESCRIPTION
This will look in the python path for a library with the name
specified in swimport.  Not quite like the original code, but it
make it possible to place the old libraries in the path and get the
old scraperwiki code working.