### PR TITLE
Fix status update failures

### DIFF
--- a/scraperwiki/utils.py
+++ b/scraperwiki/utils.py
@@ -71,7 +71,7 @@ def status(type, message=None):
     if not _in_box():
         return "Not in box"
 
-    url = os.environ.get("SW_STATUS_URL", "https://scraperwiki.com/api/status")
+    url = os.environ.get("SW_STATUS_URL", "https://app.quickcode.io/api/status")
     if url == "OFF":
         # For development mode
         return


### PR DESCRIPTION
Use QuickCode URL for status updates.

The previous https://scraperwiki.com/api/status URL now redirects to
https://app.quickcode.io/login and the status update fails silently
(the site does respond, but doesn't cause a HTTP error).