### PR TITLE
Python3 unicode

### DIFF
--- a/scraperwiki/utils.py
+++ b/scraperwiki/utils.py
@@ -57,7 +57,13 @@ def pdftoxml(pdfdata, options=""):
     #xmlfin = open(tmpxml)
     xmldata = xmlin.read()
     xmlin.close()
-    return xmldata.decode('utf-8')
+
+    try:
+        xmldata = xmldata.decode('utf-8')
+    except AttributeError:
+        pass
+
+    return xmldata
 
 
 def _in_box():


### PR DESCRIPTION
In python3 we do not have unicode strings, so we do not need to decode them.