### PR TITLE
Python3 unicode

### DIFF
--- a/scraperwiki/utils.py
+++ b/scraperwiki/utils.py
@@ -62,7 +62,7 @@ def pdftoxml(pdfdata, options=""):
     except AttributeError:
         pass
         
-    return xmldata.d
+    return xmldata
 
 
 def _in_box():

--- a/scraperwiki/utils.py
+++ b/scraperwiki/utils.py
@@ -57,7 +57,12 @@ def pdftoxml(pdfdata, options=""):
     #xmlfin = open(tmpxml)
     xmldata = xmlin.read()
     xmlin.close()
-    return xmldata.decode('utf-8')
+    try:
+        xmldata = xmldata.decode('utf-8')
+    except AttributeError:
+        pass
+        
+    return xmldata.d
 
 
 def _in_box():


### PR DESCRIPTION
In python3 we do not have unicode strings, so we do not need to decode them.