### PR TITLE
Added conditional check on 'atexit' event function: the Python interp…

### DIFF
--- a/scraperwiki/sql.py
+++ b/scraperwiki/sql.py
@@ -123,7 +123,7 @@ def commit_transactions():
     """
     Ensure any outstanding transactions are committed on exit
     """
-    if _State._transaction is not None:
+    if _State is not None and _State._transaction is not None:
         _State._transaction.commit()
         _State._transaction = None
 


### PR DESCRIPTION
…reter may remove the '_State' class before running the 'atexit' event actions, which yields a stacktrace with a 'NoneType has no _transation attribute' error. Checking on the existence of the '_State' class, and then on its attributes ensures the NoneType error does not appear.